### PR TITLE
Version 0.12.2 [2021-08-25]

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@
 Package: sansSouci
 ==================
 
+Version 0.12.2 [2021-08-25]
+
+* Remove default value for argument 'm' in 'calibrate' and 'get_pivotal_stat' to make sure that m is properly set.
+* Add unit test: the pivotal statistics are non-decreasing in the subset of hypotheses used for calibration (following feedback by Angela Andreella).
+
 Version 0.12.1 [2021-06-11]
 
 * [IIDEA] Speedup: data sets from the GSEABenchmarkeR package and associated gene sets are preprocessed on the deployment server. 

--- a/R/posthoc-bounds.R
+++ b/R/posthoc-bounds.R
@@ -124,7 +124,7 @@ plotConfCurve <- function(conf_bound, xmax, cols = NULL) {
 #' 
 #' null_groups <- replicate(100, sample(groups))
 #' p0 <- rowWelchTests(X, null_groups)$p.value
-#' calib <- calibrate(p0, alpha = 0.1)
+#' calib <- calibrate(p0, m, alpha = 0.1)
 #' thr <- calib$thr
 #' 
 #' M0 <- maxFP(p, thr)

--- a/man/calibrate.Rd
+++ b/man/calibrate.Rd
@@ -7,10 +7,10 @@
 \usage{
 calibrate(
   p0,
+  m,
   alpha,
   family = c("Linear", "Beta", "Simes"),
-  m = nrow(p0),
-  K = m,
+  K = nrow(p0),
   p = NULL,
   max_steps_down = 10L,
   piv_stat0 = NULL
@@ -18,25 +18,23 @@ calibrate(
 
 calibrate0(
   p0,
+  m,
   alpha,
   family = c("Linear", "Beta", "Simes"),
-  m = nrow(p0),
-  K = m,
+  K = nrow(p0),
   piv_stat0 = NULL
 )
 }
 \arguments{
-\item{p0}{A \verb{m x B} matrix. The j-th ow corresponds to a permutation
-of the input \code{categ}: for each hypothesis i, \code{p0[i,j]} is the
-p-value of the test of the i-th null hypothesis on the permuted categories}
+\item{p0}{A matrix with B rows. Each row is a vector of null p-values}
+
+\item{m}{The total number of tested hypotheses}
 
 \item{alpha}{A numeric value in \verb{[0,1]}, the target (JER) risk}
 
 \item{family}{A character value, the name of a threshold family. Should be
 one of "Linear", "Beta" and "Simes", or "Oracle". "Linear" and "Simes" families are
 identical.}
-
-\item{m}{The total numer of tested hypotheses. Defaults to \code{p0}}
 
 \item{K}{An integer value in \verb{[1,m]}, the number of elements in the reference family. Defaults to \code{m}}
 
@@ -80,8 +78,8 @@ p <- rowWelchTests(X, categ)$p.value
 
 null_groups <- replicate(B, sample(categ))
 p0 <- rowWelchTests(X, null_groups)$p.value
-calib0 <- calibrate0(p0, alpha = 0.1) # single step
-calib <- calibrate(p0, alpha = 0.1)
+calib0 <- calibrate0(p0, m, alpha = 0.1) # single step
+calib <- calibrate(p0, m, alpha = 0.1)
 calib$lambda >= calib0$lambda # probably very close here (null data)
 
 maxFP(p, calib$thr)
@@ -97,8 +95,9 @@ perm <- rowWelchTests(X, null_groups)
 p0 <- perm$p.value
 
 alpha <- 0.1
-calib_L <- calibrate(p0, alpha, family = "Linear")
-calib_B <- calibrate(p0, alpha, family = "Beta", K = 100)
+m <- nrow(X)
+calib_L <- calibrate(p0, m, alpha, family = "Linear")
+calib_B <- calibrate(p0, m, alpha, family = "Beta", K = 100)
 p <- rowWelchTests(X, categ)$p.value
 
 ## post hoc bounds (these are functions!)

--- a/man/get_pivotal_stat.Rd
+++ b/man/get_pivotal_stat.Rd
@@ -5,16 +5,14 @@
 \title{Get a vector of pivotal statistics associated
 to permutation p-values and to a reference family}
 \usage{
-get_pivotal_stat(p0, t_inv = t_inv_linear, m = nrow(p0), K = m)
+get_pivotal_stat(p0, m, t_inv = t_inv_linear, K = nrow(p0))
 }
 \arguments{
-\item{p0}{A \verb{m x B} matrix. The j-th ow corresponds to a permutation
-of the input \code{categ}: for each hypothesis i, \code{p0[i,j]} is the
-p-value of the test of the i-th null hypothesis on the permuted categories}
+\item{p0}{A matrix with B rows. Each row is a vector of null p-values}
+
+\item{m}{The total number of tested hypotheses}
 
 \item{t_inv}{An inverse threshold function (same I/O as 't_inv_linear')}
-
-\item{m}{The total numer of tested hypotheses. Defaults to \code{p0}}
 
 \item{K}{An integer value in \verb{[1,m]}, the number of elements in the reference family. Defaults to \code{m}}
 }
@@ -36,7 +34,7 @@ categ <- rbinom(n, 1, 0.4)
 B <- 10
 null_groups <- replicate(B, sample(categ))
 p0 <- rowWelchTests(X, null_groups)$p.value
-pivStat <- get_pivotal_stat(p0)
+pivStat <- get_pivotal_stat(p0, m)
 quantile(pivStat, 0.2)
 
 

--- a/man/maxFP.Rd
+++ b/man/maxFP.Rd
@@ -28,7 +28,7 @@ p <- rowWelchTests(X, groups)$p.value
 
 null_groups <- replicate(100, sample(groups))
 p0 <- rowWelchTests(X, null_groups)$p.value
-calib <- calibrate(p0, alpha = 0.1)
+calib <- calibrate(p0, m, alpha = 0.1)
 thr <- calib$thr
 
 M0 <- maxFP(p, thr)

--- a/tests/testthat/test_SansSouci-class.R
+++ b/tests/testthat/test_SansSouci-class.R
@@ -102,7 +102,7 @@ test_that("'fit.SansSouci' reproduces the results of 'calibrate'", {
     expect_equal(p0, res$output$p0)
     t_inv <- ifelse(fam == "Simes", t_inv_linear,  t_inv_beta)
     t_ <- ifelse(fam == "Simes", t_linear,  t_beta)
-    pivStat <- get_pivotal_stat(p0, t_inv, K = K)
+    pivStat <- get_pivotal_stat(p0, m, t_inv, K = K)
     expect_equal(pivStat, res$output$piv_stat)
 #    expect_equal(quantile(pivStat, alpha), res$output$lambda)
 #    expect_identical(cal$thr,      reso$thr)

--- a/tests/testthat/test_calibration.R
+++ b/tests/testthat/test_calibration.R
@@ -40,12 +40,12 @@ test_that("Vanilla tests for 'get_pivotal_stat'", {
     null_groups <- replicate(B, sample(categ))
     p0 <- rowWelchTests(X, null_groups)$p.value
     
-    pivStat <- get_pivotal_stat(p0)
+    pivStat <- get_pivotal_stat(p0, m)
     expect_length(pivStat, B)
     expect_lte(max(pivStat), 1)
     expect_gte(min(pivStat), 0) 
 
-    pivStat2 <- get_pivotal_stat(p0, K = m/10)
+    pivStat2 <- get_pivotal_stat(p0, m, K = m/10)
     expect_gte(min(pivStat2), 0)
     expect_gte(min(pivStat2 - pivStat), 0)
 })
@@ -60,10 +60,28 @@ test_that("JER calibration and get_pivotal_stat yield identical pivotal statisti
     ## TODO: tests all param combinations
     set.seed(0xBEEF)
     p0 <- get_perm(X, categ, B)$p.value
-    pivStat <- get_pivotal_stat(p0, t_inv_linear)
+    pivStat <- get_pivotal_stat(p0, m, t_inv_linear)
 
-    cal <- calibrate(p0, alpha = 1, family = "Linear")
+    cal <- calibrate(p0, m, alpha = 1, family = "Linear")
     expect_equal(cal$piv_stat, pivStat)
+})
+
+
+
+test_that("pivotal statistics are non-decreasing in the set of hypotheses used for calibration", {
+    m <- 132
+    n <- 54
+    X <- matrix(rnorm(m*n), ncol = n, nrow = m)
+    categ <- rbinom(n, 1, 0.4)
+    B <- 111
+    
+    p0 <- get_perm(X, categ, B)$p.value
+    piv_stat <- get_pivotal_stat(p0, m, t_inv_linear)
+    
+    sub <- sample(m, round(m/2))
+    piv_stat_sub <- get_pivotal_stat(p0[sub, ], m, t_inv_linear)
+    
+    expect_gte(min(piv_stat_sub - piv_stat_sub), 0)
 })
 
 


### PR DESCRIPTION
* Remove default value for argument 'm' in 'calibrate' and 'get_pivotal_stat' to make sure that m is properly set.
* Add unit test: the pivotal statistics are non-decreasing in the subset of hypotheses used for calibration (following feedback by Angela Andreella).